### PR TITLE
Update tag_latest_prusaslicer.sh to pull the most-recent release, including preview builds

### DIFF
--- a/tag_latest_prusaslicer.sh
+++ b/tag_latest_prusaslicer.sh
@@ -11,7 +11,7 @@ set -eu
 GH_ACTION="y"
 
 # LATEST_RELEASE -- where to find the latest PrusaSlicer release
-LATEST_RELEASE="https://api.github.com/repos/prusa3d/PrusaSlicer/releases/latest"
+LATEST_RELEASE="https://api.github.com/repos/prusa3d/PrusaSlicer/releases?per_page=1&prerelease=true"
 
 # ** end of configurable variables **
 


### PR DESCRIPTION
Now pulls a pre-release version if it's the latest tagged build. This mirrors the behavior set within PrusaSliver itself, where it will alert the user if there is a new build available, not just anything tagged "latest."