### PR TITLE
chore: update for changed naming convention for prusaslicer

### DIFF
--- a/get_latest_prusaslicer_release.sh
+++ b/get_latest_prusaslicer_release.sh
@@ -5,8 +5,8 @@ TMPDIR="$(mktemp -d)"
 curl -SsL https://api.github.com/repos/prusa3d/PrusaSlicer/releases/latest > $TMPDIR/latest.json
 
 # Grabs the first item of the latest result of the AppImage.
-url=$(jq -r '.assets[0] | select(.browser_download_url|test("linux-x64-GTK3.+.AppImage$"))| .browser_download_url' $TMPDIR/latest.json)
-name=$(jq -r '.assets[0] | select(.browser_download_url|test("linux-x64-GTK3.+.AppImage$"))| .name' $TMPDIR/latest.json)
+url=$(jq -r '.assets[] | select(.browser_download_url|test("linux-x64-older-distros-GTK3.*AppImage$"))|.browser_download_url' $TMPDIR/latest.json)
+name=$(jq -r '.assets[] | select(.browser_download_url|test("linux-x64-older-distros-GTK3.*AppImage$"))|.name' $TMPDIR/latest.json)
 version=$(jq -r .tag_name $TMPDIR/latest.json)
 
 if [ $# -ne 1 ]; then


### PR DESCRIPTION
update to build 2.8.1 and naming changes for older,newer distros